### PR TITLE
Fixed list of missing functions

### DIFF
--- a/src/content/lodash-missing.md
+++ b/src/content/lodash-missing.md
@@ -13,13 +13,13 @@
 ~~_.differenceBy~~  
 ~~_.fill~~  
 ~~_.findIndex~~  
-~~_.first -> head~~
-~~_.flatten~~
-~~_.flattenDeep~~
-~~_.join~~
+~~_.first -> head~~  
+~~_.flatten~~  
+~~_.flattenDeep~~  
+~~_.join~~  
 ~~_.head~~  
 ~~_.indexOf~~  
-~~_.lastIndexOf~~
+~~_.lastIndexOf~~  
 ~~_.tail~~  
 
     _.differenceWith


### PR DESCRIPTION
Before: 

<img width="379" alt="screen shot 2018-03-02 at 13 13 21" src="https://user-images.githubusercontent.com/435399/36900534-89bc4f38-1e1b-11e8-915b-d3d1461cc5ed.png">

After:
<img width="147" alt="screen shot 2018-03-02 at 13 14 07" src="https://user-images.githubusercontent.com/435399/36900559-9faccb42-1e1b-11e8-9fc8-49ca534785c5.png">

Even if adding two spaces is not the best way to align them 😅 