### PR TITLE
_.now() appears to have been implemented in vanilla js, so removing f…

### DIFF
--- a/src/content/lodash-missing.md
+++ b/src/content/lodash-missing.md
@@ -107,7 +107,7 @@
 
 ### Date
 
-    _.now
+~~_.now~~  
 
 ### Function
 


### PR DESCRIPTION
…rom the required list.