### PR TITLE
add lang section and some corresponding replacements

### DIFF
--- a/src/content/lodash/lang/gt/lodash.js
+++ b/src/content/lodash/lang/gt/lodash.js
@@ -1,0 +1,11 @@
+// https://lodash.com/docs/#gt
+import { gt } from 'lodash'
+
+exports.greaterThan = gt(3, 1)
+// => true
+
+exports.equalTo = gt(3, 3)
+// => false
+
+exports.lessThan = gt(1, 3)
+// => false

--- a/src/content/lodash/lang/gt/notes.md
+++ b/src/content/lodash/lang/gt/notes.md
@@ -1,0 +1,1 @@
+[mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators)

--- a/src/content/lodash/lang/gt/spec.js
+++ b/src/content/lodash/lang/gt/spec.js
@@ -1,0 +1,23 @@
+const expected = {
+  greaterThan: true,
+  equalTo: false,
+  lessThan: false,
+}
+
+const lodash = require('./lodash')
+const plain = require('./vanilla')
+
+test('greaterThan', () => {
+  expect(lodash.greaterThan).toEqual(expected.greaterThan)
+  expect(plain.greaterThan).toEqual(lodash.greaterThan)
+})
+
+test('equalTo', () => {
+  expect(lodash.equalTo).toEqual(expected.equalTo)
+  expect(plain.equalTo).toEqual(lodash.equalTo)
+})
+
+test('lessThan', () => {
+  expect(lodash.lessThan).toEqual(expected.lessThan)
+  expect(plain.lessThan).toEqual(lodash.lessThan)
+})

--- a/src/content/lodash/lang/gt/vanilla.js
+++ b/src/content/lodash/lang/gt/vanilla.js
@@ -1,0 +1,10 @@
+const gt = (a, b) => a > b
+
+exports.greaterThan = gt(3, 1)
+// => true
+
+exports.equalTo = gt(3, 3)
+// => false
+
+exports.lessThan = gt(1, 3)
+// => false

--- a/src/content/lodash/lang/gte/lodash.js
+++ b/src/content/lodash/lang/gte/lodash.js
@@ -1,0 +1,11 @@
+// https://lodash.com/docs/#gte
+import { gte } from 'lodash'
+
+exports.greaterThan = gte(3, 1)
+// => true
+
+exports.equalTo = gte(3, 3)
+// => true
+
+exports.lessThan = gte(1, 3)
+// => false

--- a/src/content/lodash/lang/gte/notes.md
+++ b/src/content/lodash/lang/gte/notes.md
@@ -1,0 +1,1 @@
+[mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators)

--- a/src/content/lodash/lang/gte/spec.js
+++ b/src/content/lodash/lang/gte/spec.js
@@ -1,0 +1,23 @@
+const expected = {
+  greaterThan: true,
+  equalTo: true,
+  lessThan: false,
+}
+
+const lodash = require('./lodash')
+const plain = require('./vanilla')
+
+test('greaterThan', () => {
+  expect(lodash.greaterThan).toEqual(expected.greaterThan)
+  expect(plain.greaterThan).toEqual(lodash.greaterThan)
+})
+
+test('equalTo', () => {
+  expect(lodash.equalTo).toEqual(expected.equalTo)
+  expect(plain.equalTo).toEqual(lodash.equalTo)
+})
+
+test('lessThan', () => {
+  expect(lodash.lessThan).toEqual(expected.lessThan)
+  expect(plain.lessThan).toEqual(lodash.lessThan)
+})

--- a/src/content/lodash/lang/gte/vanilla.js
+++ b/src/content/lodash/lang/gte/vanilla.js
@@ -1,0 +1,10 @@
+const gte = (a, b) => a >= b
+
+exports.greaterThan = gte(3, 1)
+// => true
+
+exports.equalTo = gte(3, 3)
+// => true
+
+exports.lessThan = gte(1, 3)
+// => false

--- a/src/content/lodash/lang/isArray/lodash.js
+++ b/src/content/lodash/lang/isArray/lodash.js
@@ -1,0 +1,11 @@
+// https://lodash.com/docs/#isArray
+import { isArray } from 'lodash'
+
+exports.array = isArray([1, 2, 3])
+// => true
+
+exports.dom_body_children = isArray(document.body.children)
+// => false
+
+exports.string = isArray('abc')
+// => false

--- a/src/content/lodash/lang/isArray/notes.md
+++ b/src/content/lodash/lang/isArray/notes.md
@@ -1,0 +1,1 @@
+[mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)

--- a/src/content/lodash/lang/isArray/spec.js
+++ b/src/content/lodash/lang/isArray/spec.js
@@ -1,0 +1,23 @@
+const expected = {
+  array: true,
+  dom_body_children: false,
+  string: false,
+}
+
+const lodash = require('./lodash')
+const plain = require('./vanilla')
+
+test('array', () => {
+  expect(lodash.array).toEqual(expected.array)
+  expect(plain.array).toEqual(lodash.array)
+})
+
+test('dom_body_children', () => {
+  expect(lodash.dom_body_children).toEqual(expected.dom_body_children)
+  expect(plain.dom_body_children).toEqual(lodash.dom_body_children)
+})
+
+test('string', () => {
+  expect(lodash.string).toEqual(expected.string)
+  expect(plain.string).toEqual(lodash.string)
+})

--- a/src/content/lodash/lang/isArray/vanilla.js
+++ b/src/content/lodash/lang/isArray/vanilla.js
@@ -1,0 +1,8 @@
+exports.array = Array.isArray([1, 2, 3])
+// => true
+
+exports.dom_body_children = Array.isArray(document.body.children)
+// => false
+
+exports.string = Array.isArray('abc')
+// => false

--- a/src/content/lodash/lang/isFinite/lodash.js
+++ b/src/content/lodash/lang/isFinite/lodash.js
@@ -1,0 +1,14 @@
+// https://lodash.com/docs/#isFinite
+import { isFinite } from 'lodash'
+
+exports.integer = isFinite(3)
+// => true
+
+exports.lowerBound = isFinite(Number.MIN_VALUE)
+// => true
+
+exports.infinite = isFinite(Infinity)
+// => false
+
+exports.stringNumber = isFinite('3')
+// => false

--- a/src/content/lodash/lang/isFinite/notes.md
+++ b/src/content/lodash/lang/isFinite/notes.md
@@ -1,0 +1,1 @@
+[mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite)

--- a/src/content/lodash/lang/isFinite/spec.js
+++ b/src/content/lodash/lang/isFinite/spec.js
@@ -1,0 +1,29 @@
+const expected = {
+  integer: true,
+  lowerBound: true,
+  infinite: false,
+  stringNumber: false,
+}
+
+const lodash = require('./lodash')
+const plain = require('./vanilla')
+
+test('integer', () => {
+  expect(lodash.integer).toEqual(expected.integer)
+  expect(plain.integer).toEqual(lodash.integer)
+})
+
+test('lowerBound', () => {
+  expect(lodash.lowerBound).toEqual(expected.lowerBound)
+  expect(plain.lowerBound).toEqual(lodash.lowerBound)
+})
+
+test('infinite', () => {
+  expect(lodash.infinite).toEqual(expected.infinite)
+  expect(plain.infinite).toEqual(lodash.infinite)
+})
+
+test('stringNumber', () => {
+  expect(lodash.stringNumber).toEqual(expected.stringNumber)
+  expect(plain.stringNumber).toEqual(lodash.stringNumber)
+})

--- a/src/content/lodash/lang/isFinite/vanilla.js
+++ b/src/content/lodash/lang/isFinite/vanilla.js
@@ -1,0 +1,11 @@
+exports.integer = Number.isFinite(3)
+// => true
+
+exports.lowerBound = Number.isFinite(Number.MIN_VALUE)
+// => true
+
+exports.infinite = Number.isFinite(Infinity)
+// => false
+
+exports.stringNumber = Number.isFinite('3')
+// => false

--- a/src/content/lodash/lang/isInteger/lodash.js
+++ b/src/content/lodash/lang/isInteger/lodash.js
@@ -1,0 +1,14 @@
+// https://lodash.com/docs/#isInteger
+import { isInteger } from 'lodash'
+
+exports.integer = isInteger(3)
+// => true
+
+exports.lowerBound = isInteger(Number.MIN_VALUE)
+// => false
+
+exports.infinite = isInteger(Infinity)
+// => false
+
+exports.stringNumber = isInteger('3')
+// => false

--- a/src/content/lodash/lang/isInteger/notes.md
+++ b/src/content/lodash/lang/isInteger/notes.md
@@ -1,0 +1,1 @@
+[mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger)

--- a/src/content/lodash/lang/isInteger/spec.js
+++ b/src/content/lodash/lang/isInteger/spec.js
@@ -1,0 +1,29 @@
+const expected = {
+  integer: true,
+  lowerBound: false,
+  infinite: false,
+  stringNumber: false,
+}
+
+const lodash = require('./lodash')
+const plain = require('./vanilla')
+
+test('integer', () => {
+  expect(lodash.integer).toEqual(expected.integer)
+  expect(plain.integer).toEqual(lodash.integer)
+})
+
+test('lowerBound', () => {
+  expect(lodash.lowerBound).toEqual(expected.lowerBound)
+  expect(plain.lowerBound).toEqual(lodash.lowerBound)
+})
+
+test('infinite', () => {
+  expect(lodash.infinite).toEqual(expected.infinite)
+  expect(plain.infinite).toEqual(lodash.infinite)
+})
+
+test('stringNumber', () => {
+  expect(lodash.stringNumber).toEqual(expected.stringNumber)
+  expect(plain.stringNumber).toEqual(lodash.stringNumber)
+})

--- a/src/content/lodash/lang/isInteger/vanilla.js
+++ b/src/content/lodash/lang/isInteger/vanilla.js
@@ -1,0 +1,11 @@
+exports.integer = Number.isInteger(3)
+// => true
+
+exports.lowerBound = Number.isInteger(Number.MIN_VALUE)
+// => false
+
+exports.infinite = Number.isInteger(Infinity)
+// => false
+
+exports.stringNumber = Number.isInteger('3')
+// => false

--- a/src/content/lodash/lang/isNaN/lodash.js
+++ b/src/content/lodash/lang/isNaN/lodash.js
@@ -1,0 +1,11 @@
+// https://lodash.com/docs/#isNaN
+import { isNaN } from 'lodash'
+
+exports.NaN = isNaN(NaN)
+// => true
+
+exports.NumberNaN = isNaN(Number(NaN))
+// => true
+
+exports.undef = isNaN(undefined)
+// => false

--- a/src/content/lodash/lang/isNaN/notes.md
+++ b/src/content/lodash/lang/isNaN/notes.md
@@ -1,0 +1,1 @@
+[mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN)

--- a/src/content/lodash/lang/isNaN/spec.js
+++ b/src/content/lodash/lang/isNaN/spec.js
@@ -1,0 +1,23 @@
+const expected = {
+  NaN: true,
+  NumberNaN: true,
+  undef: false,
+}
+
+const lodash = require('./lodash')
+const plain = require('./vanilla')
+
+test('NaN', () => {
+  expect(lodash.NaN).toEqual(expected.NaN)
+  expect(plain.NaN).toEqual(lodash.NaN)
+})
+
+test('NumberNaN', () => {
+  expect(lodash.NumberNaN).toEqual(expected.NumberNaN)
+  expect(plain.NumberNaN).toEqual(lodash.NumberNaN)
+})
+
+test('undef', () => {
+  expect(lodash.undef).toEqual(expected.undef)
+  expect(plain.undef).toEqual(lodash.undef)
+})

--- a/src/content/lodash/lang/isNaN/vanilla.js
+++ b/src/content/lodash/lang/isNaN/vanilla.js
@@ -1,0 +1,8 @@
+exports.NaN = Number.isNaN(NaN)
+// => true
+
+exports.NumberNaN = Number.isNaN(Number(NaN))
+// => true
+
+exports.undef = Number.isNaN(undefined)
+// => false

--- a/src/content/lodash/lang/isNil/lodash.js
+++ b/src/content/lodash/lang/isNil/lodash.js
@@ -1,0 +1,11 @@
+// https://lodash.com/docs/#isNil
+import { isNil } from 'lodash'
+
+exports.nullVal = isNil(null)
+// => true
+
+exports.undefVal = isNil(undefined)
+// => true
+
+exports.nanVal = isNil(NaN)
+// => false

--- a/src/content/lodash/lang/isNil/notes.md
+++ b/src/content/lodash/lang/isNil/notes.md
@@ -1,0 +1,1 @@
+[mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators)

--- a/src/content/lodash/lang/isNil/spec.js
+++ b/src/content/lodash/lang/isNil/spec.js
@@ -1,0 +1,23 @@
+const expected = {
+  nullVal: true,
+  undefVal: true,
+  nanVal: false,
+}
+
+const lodash = require('./lodash')
+const plain = require('./vanilla')
+
+test('nullVal', () => {
+  expect(lodash.nullVal).toEqual(expected.nullVal)
+  expect(plain.nullVal).toEqual(lodash.nullVal)
+})
+
+test('undefVal', () => {
+  expect(lodash.undefVal).toEqual(expected.undefVal)
+  expect(plain.undefVal).toEqual(lodash.undefVal)
+})
+
+test('nanVal', () => {
+  expect(lodash.nanVal).toEqual(expected.nanVal)
+  expect(plain.nanVal).toEqual(lodash.nanVal)
+})

--- a/src/content/lodash/lang/isNil/vanilla.js
+++ b/src/content/lodash/lang/isNil/vanilla.js
@@ -1,0 +1,10 @@
+const isNil = val => val == null
+
+exports.nullVal = isNil(null)
+// => true
+
+exports.undefVal = isNil(undefined)
+// => true
+
+exports.nanVal = isNil(NaN)
+// => false

--- a/src/content/lodash/lang/isNull/lodash.js
+++ b/src/content/lodash/lang/isNull/lodash.js
@@ -1,0 +1,8 @@
+// https://lodash.com/docs/#isNull
+import { isNull } from 'lodash'
+
+exports.nullVal = isNull(null)
+// => true
+
+exports.undefVal = isNull(undefined)
+// => false

--- a/src/content/lodash/lang/isNull/notes.md
+++ b/src/content/lodash/lang/isNull/notes.md
@@ -1,0 +1,1 @@
+[mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness)

--- a/src/content/lodash/lang/isNull/spec.js
+++ b/src/content/lodash/lang/isNull/spec.js
@@ -1,0 +1,17 @@
+const expected = {
+  nullVal: true,
+  undefVal: false,
+}
+
+const lodash = require('./lodash')
+const plain = require('./vanilla')
+
+test('nullVal', () => {
+  expect(lodash.nullVal).toEqual(expected.nullVal)
+  expect(plain.nullVal).toEqual(lodash.nullVal)
+})
+
+test('undefVal', () => {
+  expect(lodash.undefVal).toEqual(expected.undefVal)
+  expect(plain.undefVal).toEqual(lodash.undefVal)
+})

--- a/src/content/lodash/lang/isNull/vanilla.js
+++ b/src/content/lodash/lang/isNull/vanilla.js
@@ -1,0 +1,7 @@
+const isNull = val => val === null
+
+exports.nullVal = isNull(null)
+// => true
+
+exports.undefVal = isNull(undefined)
+// => false

--- a/src/content/lodash/lang/isUndefined/lodash.js
+++ b/src/content/lodash/lang/isUndefined/lodash.js
@@ -1,0 +1,8 @@
+// https://lodash.com/docs/#isUndefined
+import { isUndefined } from 'lodash'
+
+exports.undefVal = isUndefined(undefined)
+// => true
+
+exports.nullVal = isUndefined(null)
+// => false

--- a/src/content/lodash/lang/isUndefined/notes.md
+++ b/src/content/lodash/lang/isUndefined/notes.md
@@ -1,0 +1,1 @@
+[mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness)

--- a/src/content/lodash/lang/isUndefined/spec.js
+++ b/src/content/lodash/lang/isUndefined/spec.js
@@ -1,0 +1,17 @@
+const expected = {
+  nullVal: false,
+  undefVal: true,
+}
+
+const lodash = require('./lodash')
+const plain = require('./vanilla')
+
+test('nullVal', () => {
+  expect(lodash.nullVal).toEqual(expected.nullVal)
+  expect(plain.nullVal).toEqual(lodash.nullVal)
+})
+
+test('undefVal', () => {
+  expect(lodash.undefVal).toEqual(expected.undefVal)
+  expect(plain.undefVal).toEqual(lodash.undefVal)
+})

--- a/src/content/lodash/lang/isUndefined/vanilla.js
+++ b/src/content/lodash/lang/isUndefined/vanilla.js
@@ -1,0 +1,7 @@
+const isUndefined = val => val === undefined
+
+exports.undefVal = isUndefined(undefined)
+// => true
+
+exports.nullVal = isUndefined(null)
+// => false


### PR DESCRIPTION
- @cedmax I refactored the inline comparisons into functions as discussed in https://github.com/cedmax/youmightnotneed/pull/46
- Added the `lang` section and some corresponding replacements for `lodash` functions